### PR TITLE
For some reason in juce it seems that all signals must be re-registred 

### DIFF
--- a/Source/g3log/stacktrace_windows.hpp
+++ b/Source/g3log/stacktrace_windows.hpp
@@ -17,6 +17,8 @@
 #error "stacktrace_win.cpp used but not on a windows system"
 #endif
 
+#define g2_thread_local __declspec(thread) 
+
 #include <string>
 #include <windows.h>
 #include "crashhandler.hpp"


### PR DESCRIPTION
re-registration per thread doesn't hurt in either case.   Ive tested this with 50ms or shorter interval and it seems to work for SIGTERM, SIGABRT, AccessViolation 

Hopefully this was the last issue. Please let me know if you find more. 

